### PR TITLE
Use pydantic settings for configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,17 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "APScheduler>=3.6.3",
     "python-telegram-bot>=13.6",
-    "python-dotenv>=0.15.0",
+    "pydantic>=2.7",
+    "pydantic-settings>=2.0",
     "SQLAlchemy>=1.4.23",
-    "telethon>=1.20",
 ]
 requires-python = ">=3.11"
+
+[project.optional-dependencies]
+tests = [
+    "telethon>=1.20",
+]
 
 [tool.setuptools]
 packages = ["src"]


### PR DESCRIPTION
## Summary
- replace manual env parsing with pydantic-based configuration
- add pydantic and pydantic-settings dependencies
- validate DATABASE_URL using PostgresDsn and drop unused dependencies

## Testing
- `deptry --package-module-name-map python-telegram-bot=telegram --pep621-dev-dependency-groups tests --known-first-party src src`
- `ruff format`
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68962de2a92083339f9163b12ca38aa7